### PR TITLE
Add better state tracking by hiding non active elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,18 +144,19 @@ export default {
 
 You can pass various attributes to the component to modify its behavior, Example with color attribute: <cron-input-ui color="#d58512"></cron-input-ui>
 
-|        Name        |    Type     | Default Value | Description                                                                                                                                                       |
-|:------------------:|:-----------:|:-------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|     **`name`**     | `{String}`  |    `cron`     | The name that the form variable                                                                                                                                   |
-|    **`width`**     | `{String}`  |    `234px`    | The width of the component input                                                                                                                                  |
-|    **`height`**    | `{String}`  |    `34px`     | The height of the component input                                                                                                                                 |
-|    **`value`**     | `{String}`  |  `* * * * *`  | Allow to set a default value on the component                                                                                                                     |
-|    **`color`**     | `{String}`  |   `#d58512`   | The main color that the component elements will take, (hexadecimal recommended)                                                                                   |
-|   **`required`**   | `{Boolean}` |    `false`    | Allow component to be empty, if set, the form will not validate when empty                                                                                        |
-| **`hot-validate`** | `{Boolean}` |    `false`    | Enable cron validation while editing it, if not set, it will only be validated when the submit event is performed within a form or by clicking on the save button |
-| **`show-message`** | `{Boolean}` |    `false`    | Display the cron representation in human language below the input (always visible in cron modal and on hover of the input)                                        |
-|   **`no-input`**   | `{Boolean}` |    `false`    | Disable the input and only allow the cron to be edited in the modal                                                                                               |
-| **`default-tab`**  | `{String}`  |   `minutes`   | The default tab that will be displayed when the component is loaded, it can be: `minutes`, `hours`, `days-of-month`, `months`, `days-of-week` or `year`           |
+|         Name          |    Type     | Default Value | Description                                                                                                                                                       |
+|:---------------------:|:-----------:|:-------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|      **`name`**       | `{String}`  |    `cron`     | The name that the form variable                                                                                                                                   |
+|      **`width`**      | `{String}`  |    `234px`    | The width of the component input                                                                                                                                  |
+|     **`height`**      | `{String}`  |    `34px`     | The height of the component input                                                                                                                                 |
+|      **`value`**      | `{String}`  |  `* * * * *`  | Allow to set a default value on the component                                                                                                                     |
+|      **`color`**      | `{String}`  |   `#d58512`   | The main color that the component elements will take (hexadecimal recommended)                                                                                    |
+|    **`required`**     | `{Boolean}` |    `false`    | Allow component to be empty, if set, the form will not validate when empty                                                                                        |
+|  **`hot-validate`**   | `{Boolean}` |    `false`    | Enable cron validation while editing it, if not set, it will only be validated when the submit event is performed within a form or by clicking on the save button |
+|  **`show-message`**   | `{Boolean}` |    `false`    | Display the cron representation in human language below the input (always visible in cron modal and on hover of the input)                                        |
+|    **`no-input`**     | `{Boolean}` |    `false`    | Disable the input and only allow the cron to be edited in the modal                                                                                               |
+| **`hide-other-tabs`** | `{Boolean}` |    `false`    | Hide the tabs that are not selected, useful when you want to show the current clicked tab for the user (more UX)                                                  |
+|   **`default-tab`**   | `{String}`  |   `minutes`   | The default tab that will be displayed when the component is loaded, it can be: `minutes`, `hours`, `days-of-month`, `months`, `days-of-week` or `year`           |
 
 ## Languages
 

--- a/src/index.css
+++ b/src/index.css
@@ -278,6 +278,9 @@ cron-input-ui .panel-group {
 
 cron-input-ui .panel-group > .panel {
     width: 50%;
+    height: -webkit-fit-content;
+    height: -moz-fit-content;
+    height: fit-content;
 }
 
 cron-input-ui .panel {
@@ -488,5 +491,9 @@ cron-input-ui .container .checkmark:after {
 cron-input-ui .panel-body[data-focused="false"] {
     display: none;
 }
+
 cron-input-ui .panel-body[data-focused="true"] {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -484,3 +484,9 @@ cron-input-ui .container .checkmark:after {
     -ms-transform: rotate(45deg);
     transform: rotate(45deg);
 }
+
+cron-input-ui .panel-body[data-focused="false"] {
+    display: none;
+}
+cron-input-ui .panel-body[data-focused="true"] {
+}

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
 
 <body>
     <form method="get">
-        <cron-input-ui height="34px" width="250px" color="#052a89" no-input="true">
+        <cron-input-ui height="34px" width="250px" color="#052a89" no-input="true" hide-other-tabs="true">
         </cron-input-ui>
         <br>
         <cron-input-ui height="68px" width="12%" color="5f963d"

--- a/src/nodes/CronExpressionInput.js
+++ b/src/nodes/CronExpressionInput.js
@@ -29,6 +29,7 @@ export class CronExpressionInput extends CronComponent {
         this.showMessage = [true, 'true', ''].includes(this.getAttribute('show-message'));
         this.noInput = [true, 'true', ''].includes(this.getAttribute('no-input'));
         this.defaultTab = this.getAttribute('default-tab') || 'minutes';
+        this.hideOtherTabs = [true, 'true', ''].includes(this.getAttribute('hide-other-tabs'));
         this.color = this.getAttribute('color') || '#d58512';
         this.colorMain = '#' + this.color.replace('#', '');
         this.colorSecond = this.increaseBrightness(this.colorMain, 30);
@@ -136,22 +137,24 @@ export class CronExpressionInput extends CronComponent {
         }
 
         // Track the selected panel-body
-        this.getElements('.form-check-input').forEach((element) => {
-            element.onchange = function () {
-                var checked = element.checked;
-                if (!checked) {
-                    return;
-                }
-                var formPanel = element.closest('.panel-form').querySelectorAll('.panel-body');
-                formPanel.forEach((panel) => {
-                    panel.dataset.focused = false;
-                });
-                var closestPanel = element.closest('.panel').querySelector('.panel-body');
-                if (closestPanel) {
-                    closestPanel.dataset.focused = true;
-                }
-            };
-        });
+        if (this.hideOtherTabs) {
+            this.getElements('.form-check-input').forEach((element) => {
+                element.onchange = function () {
+                    var checked = element.checked;
+                    if (!checked) {
+                        return;
+                    }
+                    var formPanel = element.closest('.panel-form').querySelectorAll('.panel-body');
+                    formPanel.forEach((panel) => {
+                        panel.dataset.focused = false;
+                    });
+                    var closestPanel = element.closest('.panel').querySelector('.panel-body');
+                    if (closestPanel) {
+                        closestPanel.dataset.focused = true;
+                    }
+                };
+            });
+        }
     }
     validator(self) {
         var insideInput = self.querySelector('.cronInsideInput');
@@ -228,7 +231,9 @@ export class CronExpressionInput extends CronComponent {
         var choices = form.querySelectorAll('input[name=choice]');
         choices.forEach((choice) => choice.removeAttribute('checked'));
         choices[type - 1].checked = true;
-        choices[type - 1].onchange();
+        if (this.hideOtherTabs) {
+            choices[type - 1].onchange();
+        }
 
         switch (type) {
             case 1:

--- a/src/nodes/CronExpressionInput.js
+++ b/src/nodes/CronExpressionInput.js
@@ -86,7 +86,7 @@ export class CronExpressionInput extends CronComponent {
         });
         this.addEvent('li > a', 'click', (scope) => {
             var index = 0;
-            self.getElements('li > a').forEach(function (elem, i) {
+            self.getElements('li > a').forEach((elem, i) => {
                 elem.parentNode.setAttribute('class', 'nav-item');
                 if (elem == scope) {
                     index = i;
@@ -118,20 +118,16 @@ export class CronExpressionInput extends CronComponent {
                 }
             }
 
-            self.setValue(
-                self.generateCron(
-                    parseInt(node.getAttribute('pos')),
-                    self.getElement('.cronInsideInput').value,
-                    node.value
-                )
-            );
+            var nodePos = parseInt(node.getAttribute('pos'));
+            var cronValue = self.generateCron(nodePos, self.getElement('.cronInsideInput').value, node.value);
+            self.setValue(cronValue);
 
             if (self.hotValidate) {
                 self.validator(self);
             }
         });
 
-        this.getElements('.propagationClass').forEach(function (element) {
+        this.getElements('.propagationClass').forEach((element) => {
             element.addEventListener('input', (e) => e.stopPropagation());
         });
 
@@ -140,23 +136,21 @@ export class CronExpressionInput extends CronComponent {
         }
 
         // Track the selected panel-body
-        this.getElements('.form-check-input').forEach(function (element) {
-            element.onchange = function(e) {
+        this.getElements('.form-check-input').forEach((element) => {
+            element.onchange = function () {
                 var checked = element.checked;
                 if (!checked) {
                     return;
                 }
-                var form = element.closest('.panel-form');
-                form.querySelectorAll('.panel-body').forEach(function (panel) {
+                var formPanel = element.closest('.panel-form').querySelectorAll('.panel-body');
+                formPanel.forEach((panel) => {
                     panel.dataset.focused = false;
                 });
                 var closestPanel = element.closest('.panel').querySelector('.panel-body');
-                console.log(element.closest('.panel').querySelector('.panel-body'));
                 if (closestPanel) {
                     closestPanel.dataset.focused = true;
                 }
-            }
-            // element.onchange();
+            };
         });
     }
     validator(self) {
@@ -236,32 +230,25 @@ export class CronExpressionInput extends CronComponent {
         choices[type - 1].checked = true;
         choices[type - 1].onchange();
 
-
         switch (type) {
             case 1:
                 var freq = this.getTypeFrequency(value);
                 var decrementFreq = 1 - decrement;
-                form.querySelector('*[match=every]').selectedIndex =
-                    parseInt(freq['every']) + decrementFreq;
-                form.querySelector('*[match=start]').selectedIndex =
-                    parseInt(freq['start']) + decrementFreq;
+                form.querySelector('*[match=every]').selectedIndex = parseInt(freq['every']) + decrementFreq;
+                form.querySelector('*[match=start]').selectedIndex = parseInt(freq['start']) + decrementFreq;
                 break;
             case 2:
                 var range = this.getTypeRange(value);
-                form.querySelector('*[match=rangeMin]').selectedIndex =
-                    parseInt(range['min']) - decrement;
-                form.querySelector('*[match=rangeMax]').selectedIndex =
-                    parseInt(range['max']) - decrement;
+                form.querySelector('*[match=rangeMin]').selectedIndex = parseInt(range['min']) - decrement;
+                form.querySelector('*[match=rangeMax]').selectedIndex = parseInt(range['max']) - decrement;
                 break;
             case 3:
                 var cs = this.getTypeChoice(value);
-                form
-                    .querySelectorAll('*[match=specific] input')
-                    .forEach((element, index) => {
-                        if (cs.includes((index + decrement).toString())) {
-                            element.checked = true;
-                        }
-                    });
+                form.querySelectorAll('*[match=specific] input').forEach((element, index) => {
+                    if (cs.includes((index + decrement).toString())) {
+                        element.checked = true;
+                    }
+                });
                 break;
         }
     }

--- a/src/nodes/CronExpressionInput.js
+++ b/src/nodes/CronExpressionInput.js
@@ -131,13 +131,33 @@ export class CronExpressionInput extends CronComponent {
             }
         });
 
-        this.getElements('.propagationClass').forEach((element) =>
-            element.addEventListener('input', (e) => e.stopPropagation())
-        );
+        this.getElements('.propagationClass').forEach(function (element) {
+            element.addEventListener('input', (e) => e.stopPropagation());
+        });
 
         if (self.hotValidate) {
             this.validator(self);
         }
+
+        // Track the selected panel-body
+        this.getElements('.form-check-input').forEach(function (element) {
+            element.onchange = function(e) {
+                var checked = element.checked;
+                if (!checked) {
+                    return;
+                }
+                var form = element.closest('.panel-form');
+                form.querySelectorAll('.panel-body').forEach(function (panel) {
+                    panel.dataset.focused = false;
+                });
+                var closestPanel = element.closest('.panel').querySelector('.panel-body');
+                console.log(element.closest('.panel').querySelector('.panel-body'));
+                if (closestPanel) {
+                    closestPanel.dataset.focused = true;
+                }
+            }
+            // element.onchange();
+        });
     }
     validator(self) {
         var insideInput = self.querySelector('.cronInsideInput');
@@ -214,6 +234,9 @@ export class CronExpressionInput extends CronComponent {
         var choices = form.querySelectorAll('input[name=choice]');
         choices.forEach((choice) => choice.removeAttribute('checked'));
         choices[type - 1].checked = true;
+        choices[type - 1].onchange();
+
+
         switch (type) {
             case 1:
                 var freq = this.getTypeFrequency(value);


### PR DESCRIPTION
https://github.com/QuentiumYT/CronInputUI/issues/4

Usability feedback from end users, many find it difficult to work out which "thing" they should select.

This improves that slightly by using accordian style logic to hide non active areas.
https://github.com/user-attachments/assets/c315fb36-99b5-4ad1-92bc-eaed9b49b8f2

